### PR TITLE
Fix the pendingIntent issue on devices with API 31+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation rootProject.ext.AndroidXDependencies.coreSplashscreen
     kapt rootProject.ext.AndroidXDependencies.hiltCompiler
     implementation rootProject.ext.AndroidXDependencies.hiltNavigationCompose
-    implementation rootProject.ext.AndroidXDependencies.hiltWork
     implementation rootProject.ext.AndroidXDependencies.lifecycleRuntimeKtx
     implementation rootProject.ext.AndroidXDependencies.lifecycleViewmodelCompose
     implementation rootProject.ext.AndroidXDependencies.navigationRuntimeKtx

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,6 @@ ext {
     coreKtx = "1.8.0"
     coreSplashscreen = "1.0.0-rc01"
     hiltNavigationCompose = "1.0.0"
-    hiltWork = "1.0.0"
     hiltCompiler = "1.0.0"
     lifecycleRuntimeKtx = "2.5.0"
     lifecycleViewmodelCompose = "2.5.0"
@@ -48,7 +47,6 @@ ext {
             coreSplashscreen         : "androidx.core:core-splashscreen:$coreSplashscreen",
             hiltCompiler             : "androidx.hilt:hilt-compiler:$hiltCompiler",
             hiltNavigationCompose    : "androidx.hilt:hilt-navigation-compose:$hiltNavigationCompose",
-            hiltWork                 : "androidx.hilt:hilt-work:$hiltWork",
             lifecycleRuntimeKtx      :
                     "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleRuntimeKtx",
             lifecycleViewmodelCompose:


### PR DESCRIPTION
Fix the Missing PendingIntent mutability flag issue caused by the Hilt-work lib which we don't need